### PR TITLE
Using 1.20.0 ? 

### DIFF
--- a/00-installer-kind.sh
+++ b/00-installer-kind.sh
@@ -21,7 +21,7 @@ function header_text {
 
 header_text "Starting Knative on kind!"
 
-kind create cluster
+kind create cluster --image=kindest/node:v1.20.0
 header_text "Waiting for core k8s services to initialize"
 sleep 5; while echo && kubectl get pods -n kube-system | grep -v -E "(Running|Completed|STATUS)"; do sleep 5; done
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


Is forcing k8s 1.20.1 to harsh?   (default it goes to 1.19.1, with the `0.9.0` version of the `kind` tool)