### PR TITLE
Using latest versions

### DIFF
--- a/samples/01-k8s-source_ksvc/020-k8s-events.yaml
+++ b/samples/01-k8s-source_ksvc/020-k8s-events.yaml
@@ -1,4 +1,4 @@
-apiVersion: sources.knative.dev/v1beta1
+apiVersion: sources.knative.dev/v1
 kind: ApiServerSource
 metadata:
   name: testevents

--- a/samples/01-ping-source_ksvc/020-ping-source.yaml
+++ b/samples/01-ping-source_ksvc/020-ping-source.yaml
@@ -1,10 +1,10 @@
-apiVersion: sources.knative.dev/v1beta1
+apiVersion: sources.knative.dev/v1
 kind: PingSource
 metadata:
   name: ping-source
 spec:
   schedule: "* * * * *"
-  jsonData: '{"message": "Hello world!"}'
+  data: '{"message": "Hello world!"}'
   sink:
     ref:
       apiVersion: serving.knative.dev/v1

--- a/samples/02-source_channel/020-k8s-events.yaml
+++ b/samples/02-source_channel/020-k8s-events.yaml
@@ -1,4 +1,4 @@
-apiVersion: sources.knative.dev/v1beta1
+apiVersion: sources.knative.dev/v1
 kind: ApiServerSource
 metadata:
   name: testevents02

--- a/samples/02-source_channel/020-ping-source.yaml
+++ b/samples/02-source_channel/020-ping-source.yaml
@@ -1,10 +1,10 @@
-apiVersion: sources.knative.dev/v1beta1
+apiVersion: sources.knative.dev/v1
 kind: PingSource
 metadata:
   name: ping-ch-source
 spec:
   schedule: "* * * * *"
-  jsonData: '{"message": "Hello world!"}'
+  data: '{"message": "Hello world!"}'
   sink:
     ref:
       apiVersion: messaging.knative.dev/v1

--- a/samples/03-source_broker/020-k8s-events.yaml
+++ b/samples/03-source_broker/020-k8s-events.yaml
@@ -1,4 +1,4 @@
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1
 kind: ApiServerSource
 metadata:
   name: k8s-source-broker

--- a/samples/03-source_broker/020-ping-source.yaml
+++ b/samples/03-source_broker/020-ping-source.yaml
@@ -1,10 +1,10 @@
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1
 kind: PingSource
 metadata:
   name: ping-source-broker
 spec:
   schedule: "*/1 * * * *"
-  jsonData: '{"message": "Hello world!"}'
+  data: '{"message": "Hello world!"}'
   sink:
     ref:
       apiVersion: eventing.knative.dev/v1


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

`v1` is now a thing for sources!